### PR TITLE
Split up readable and editable module endpoints

### DIFF
--- a/src/main/java/org/fsg1/fmms/backend/endpoints/EditableModuleEndpoint.java
+++ b/src/main/java/org/fsg1/fmms/backend/endpoints/EditableModuleEndpoint.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
  * The class containing the 'modules' endpoints.
  */
 @Path("")
-public class ModulesEndpoint extends Endpoint<ModulesService> {
+public class EditableModuleEndpoint extends Endpoint<ModulesService> {
     /**
      * Constructor which receives the service as dependency. In subclasses this dependency is automatically
      * injected by Jersey's DPI system.
@@ -21,27 +21,8 @@ public class ModulesEndpoint extends Endpoint<ModulesService> {
      * @param service Service object.
      */
     @Inject
-    ModulesEndpoint(final ModulesService service) {
+    EditableModuleEndpoint(final ModulesService service) {
         super(service);
-    }
-
-    /**
-     * Returns a module.
-     *
-     * @param curriculumId Identifier of the curriculum.
-     * @param moduleId     Identifier of the module.
-     * @return A JSON list of all semesters in this curriculum.
-     * @throws Exception In case the querying goes wrong.
-     */
-    @GET
-    @Path("curriculum/{curriculum_id}/module/{module_id}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response getModuleInformation(@PathParam("curriculum_id") final int curriculumId,
-                                         @PathParam("module_id") final String moduleId) throws Exception {
-        final ModulesService service = getService();
-        final JsonNode result = service.get(service.getQueryModuleInformation(), "module", moduleId, curriculumId);
-        final String jsonString = result.toString();
-        return Response.status(Response.Status.OK).entity(jsonString).build();
     }
 
     /**

--- a/src/main/java/org/fsg1/fmms/backend/endpoints/EditableModuleEndpoint.java
+++ b/src/main/java/org/fsg1/fmms/backend/endpoints/EditableModuleEndpoint.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
- * The class containing the 'modules' endpoints.
+ * The class containing the 'modules' endpoints that are used to edit a module.
  */
 @Path("")
 public class EditableModuleEndpoint extends Endpoint<ModulesService> {

--- a/src/main/java/org/fsg1/fmms/backend/endpoints/ReadableModuleEndpoint.java
+++ b/src/main/java/org/fsg1/fmms/backend/endpoints/ReadableModuleEndpoint.java
@@ -1,0 +1,45 @@
+package org.fsg1.fmms.backend.endpoints;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.fsg1.fmms.backend.services.ModulesService;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("curriculum/{curriculum_id}/module/{module_id}")
+public class ReadableModuleEndpoint extends Endpoint<ModulesService> {
+
+    /**
+     * Constructor which receives the service as dependency. In subclasses this dependency is automatically
+     * injected by Jersey's DPI system.
+     *
+     * @param service Service object.
+     */
+    @Inject
+    ReadableModuleEndpoint(ModulesService service) {
+        super(service);
+    }
+
+    /**
+     * Returns a module.
+     *
+     * @param curriculumId Identifier of the curriculum.
+     * @param moduleId     Identifier of the module.
+     * @return A JSON list of all semesters in this curriculum.
+     * @throws Exception In case the querying goes wrong.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getModuleInformation(@PathParam("curriculum_id") final int curriculumId,
+                                         @PathParam("module_id") final String moduleId) throws Exception {
+        final ModulesService service = getService();
+        final JsonNode result = service.get(service.getQueryModuleInformation(), "module", moduleId, curriculumId);
+        final String jsonString = result.toString();
+        return Response.status(Response.Status.OK).entity(jsonString).build();
+    }
+}

--- a/src/main/java/org/fsg1/fmms/backend/endpoints/ReadableModuleEndpoint.java
+++ b/src/main/java/org/fsg1/fmms/backend/endpoints/ReadableModuleEndpoint.java
@@ -11,6 +11,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+/**
+ * The class containing the 'modules' endpoints that are used to only display a module.
+ */
 @Path("curriculum/{curriculum_id}/module/{module_id}")
 public class ReadableModuleEndpoint extends Endpoint<ModulesService> {
 
@@ -21,7 +24,7 @@ public class ReadableModuleEndpoint extends Endpoint<ModulesService> {
      * @param service Service object.
      */
     @Inject
-    ReadableModuleEndpoint(ModulesService service) {
+    ReadableModuleEndpoint(final ModulesService service) {
         super(service);
     }
 

--- a/src/test/java/org/fsg1/fmms/backend/endpoints/ModuleEndpointsTest.java
+++ b/src/test/java/org/fsg1/fmms/backend/endpoints/ModuleEndpointsTest.java
@@ -20,14 +20,11 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.core.MediaType;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
@@ -36,7 +33,7 @@ import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ModulesEndpointTest extends JerseyTest {
+public class ModuleEndpointsTest extends JerseyTest {
 
     private static RequestSpecification spec;
     private ObjectMapper mapper = new ObjectMapper();
@@ -57,7 +54,8 @@ public class ModulesEndpointTest extends JerseyTest {
     @Override
     public ResourceConfig configure() {
         return new ResourceConfig()
-                .register(ModulesEndpoint.class)
+                .register(EditableModuleEndpoint.class)
+                .register(ReadableModuleEndpoint.class)
                 .register(new AbstractBinder() {
                     @Override
                     protected void configure() {


### PR DESCRIPTION
If the paths on a method and class overlap it breaks apparently.